### PR TITLE
Fix Makefile to reference correct libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 *.o
 *.obj
 *.exe
+cmdc
+gimgch
+gimgextract
+gimgfixcmd
+gimginfo
+gimgunlock
+gimgxor

--- a/Makefile
+++ b/Makefile
@@ -2,28 +2,29 @@ CFLAGS = -Wall
 GIMGLIB_SOURCES = gimglib.c util.c sf_typ.c sf_mps.c sf_tre.c sf_rgn.c sf_lbl.c sf_net.c sf_nod.c sf_dem.c sf_mar.c sf_gmp.c
 GIMGLIB_OBJS = $(GIMGLIB_SOURCES:.c=.o)
 LIBS= -liconv
+
 all: gimginfo gimgfixcmd gimgxor gimgunlock gimgch gimgextract cmdc
 
 gimginfo: gimginfo.o $(GIMGLIB_OBJS)
-	$(CC) -o $@ $^ -lm  ${LIBS}
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgfixcmd: gimgfixcmd.o cmdlib.o $(GIMGLIB_OBJS)
-	$(CC) -o $@ $^ -lm  ${LIBS}
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgxor: gimgxor.o
-	$(CC) -o $@ $^ -lm  ${LIBS}
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgunlock: gimgunlock.o util_indep.o
-	$(CC) -o $@ $^ -lm  ${LIBS}
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgch: gimgch.o util_indep.o
-	$(CC) -o $@ $^ -lm  ${LIBS}
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgextract: gimgextract.o util_indep.o
-	$(CC) -o $@ $^ -lm  ${LIBS}
+	$(CC) -o $@ $^ ${LIBS}
 
 cmdc: cmdc.o
-	$(CC) -o $@ $^ -lm  ${LIBS}
+	$(CC) -o $@ $^ ${LIBS}
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,30 @@
-CC = gcc
-CFLAGS = -Wall -D_FILE_OFFSET_BITS=64
+CFLAGS = -Wall 
 GIMGLIB_SOURCES = gimglib.c util.c sf_typ.c sf_mps.c sf_tre.c sf_rgn.c sf_lbl.c sf_net.c sf_nod.c sf_dem.c sf_mar.c sf_gmp.c
 GIMGLIB_OBJS = $(GIMGLIB_SOURCES:.c=.o)
+LIBS= -liconv
 
 all: gimginfo gimgfixcmd gimgxor gimgunlock gimgch gimgextract cmdc
 
 gimginfo: gimginfo.o $(GIMGLIB_OBJS)
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgfixcmd: gimgfixcmd.o cmdlib.o $(GIMGLIB_OBJS)
-	$(CC) -o $@ $^ -lm
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgxor: gimgxor.o
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgunlock: gimgunlock.o util_indep.o
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgch: gimgch.o util_indep.o
+	$(CC) -o $@ $^ ${LIBS}
 
 gimgextract: gimgextract.o util_indep.o
+	$(CC) -o $@ $^ ${LIBS}
 
 cmdc: cmdc.o
-	$(CC) -o $@ $< -lm
+	$(CC) -o $@ $^ ${LIBS}
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-CFLAGS = -Wall 
+CC = gcc
+CFLAGS = -Wall -D_FILE_OFFSET_BITS=64
 GIMGLIB_SOURCES = gimglib.c util.c sf_typ.c sf_mps.c sf_tre.c sf_rgn.c sf_lbl.c sf_net.c sf_nod.c sf_dem.c sf_mar.c sf_gmp.c
 GIMGLIB_OBJS = $(GIMGLIB_SOURCES:.c=.o)
-LIBS= -liconv
+LIBS= -liconv -lm
 
 all: gimginfo gimgfixcmd gimgxor gimgunlock gimgch gimgextract cmdc
 

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,29 @@
-CC = gcc
-CFLAGS = -Wall -D_FILE_OFFSET_BITS=64
+CFLAGS = -Wall 
 GIMGLIB_SOURCES = gimglib.c util.c sf_typ.c sf_mps.c sf_tre.c sf_rgn.c sf_lbl.c sf_net.c sf_nod.c sf_dem.c sf_mar.c sf_gmp.c
 GIMGLIB_OBJS = $(GIMGLIB_SOURCES:.c=.o)
-
+LIBS= -liconv
 all: gimginfo gimgfixcmd gimgxor gimgunlock gimgch gimgextract cmdc
 
 gimginfo: gimginfo.o $(GIMGLIB_OBJS)
+	$(CC) -o $@ $^ -lm  ${LIBS}
 
 gimgfixcmd: gimgfixcmd.o cmdlib.o $(GIMGLIB_OBJS)
-	$(CC) -o $@ $^ -lm
+	$(CC) -o $@ $^ -lm  ${LIBS}
 
 gimgxor: gimgxor.o
+	$(CC) -o $@ $^ -lm  ${LIBS}
 
 gimgunlock: gimgunlock.o util_indep.o
+	$(CC) -o $@ $^ -lm  ${LIBS}
 
 gimgch: gimgch.o util_indep.o
+	$(CC) -o $@ $^ -lm  ${LIBS}
 
 gimgextract: gimgextract.o util_indep.o
+	$(CC) -o $@ $^ -lm  ${LIBS}
 
 cmdc: cmdc.o
-	$(CC) -o $@ $< -lm
+	$(CC) -o $@ $^ -lm  ${LIBS}
 
 .PHONY: clean
 clean:

--- a/gimgunlock.c
+++ b/gimgunlock.c
@@ -216,14 +216,14 @@ int main (int argc, char *argv[])
 	FILE *fp;
 	struct patch_struct *patch;
 
-	if (argc != 2) {
-		printf("usage: %s file.img\n", argv[0]);
+	if (argc != 3) {
+		printf("usage: %s <input file> <output file>\n", argv[0]);
 		return 1;
 	}
 	if (strcmp(argv[1], "-h") == 0 ||
 			strcmp(argv[1], "--help") == 0 ||
 			strcmp(argv[1], "-?") == 0) {
-		printf("usage: %s file.img\n", argv[0]);
+		printf("usage: %s <input file> <output file>\n", argv[0]);
 		return 1;
 	}
 
@@ -238,10 +238,10 @@ int main (int argc, char *argv[])
 	if (patch == NULL)
 		return 1;
 
-	printf("Writing to file.\n");
-	fp = fopen(argv[1], "rb+");
+	printf("Writing to file:%s\n", argv[2]);
+	fp = fopen(argv[2], "rb+");
 	if (fp == NULL) {
-		printf("can't open %s for writing\n", argv[1]);
+		printf("can't open %s for writing\n", argv[2]);
 		return 1;
 	}
 	apply_patch(fp, patch);


### PR DESCRIPTION
The following change will make it build nicely on Mac OS X 10.9, by referencing the correct libiconv.dylib (iconv).
